### PR TITLE
Avoid unnecessary redirects that add a trailing slash

### DIFF
--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -74,10 +74,10 @@ module ApplicationHelpers
 
   def booklet_nav(page)
     previous_page = page - 1
-    previous_path = previous_page > 0 ? "/#{ current_booklet }/#{ previous_page }" : "/#{ current_booklet }"
+    previous_path = previous_page > 0 ? "/#{ current_booklet }/#{ previous_page }/" : "/#{ current_booklet }/"
 
     next_page = page + 1
-    next_path = "/#{ current_booklet }/#{ next_page }"
+    next_path = "/#{ current_booklet }/#{ next_page }/"
 
     links = ''
     links += link_to(content_tag(:i, '', class: 'fa fa-arrow-left fa-lg'), l(previous_path), class: 'btn btn-default') if booklet_page_exists?(current_booklet, previous_page)

--- a/source/layouts/_navigation.slim
+++ b/source/layouts/_navigation.slim
@@ -12,9 +12,9 @@
             = t "#{ current_booklet }.title"
           span.caret
         ul.dropdown-menu role='menu'
-          li = link_to t('kgp.title'), l('/kgp')
-          li = link_to t('fourlaws.title'), l('/fourlaws')
-          li = link_to t('satisfied.title'), l('/satisfied')
+          li = link_to t('kgp.title'), l('/kgp/')
+          li = link_to t('fourlaws.title'), l('/fourlaws/')
+          li = link_to t('satisfied.title'), l('/satisfied/')
 
       li.dropdown
         a.dropdown-toggle data-toggle='dropdown' role='button' aria-expanded='false'
@@ -26,4 +26,3 @@
           - langs_sorted = langs.sort { |a, b| language_name_in_locale(a) <=> language_name_in_locale(b) }
           - langs_sorted.reject { |l| l == :unspecified }.each do |lang|
             li = link_to language_selection_s(lang), l(current_page.path, lang)
-


### PR DESCRIPTION
Explicitly add a trailing slash to some links to avoid a redirect.
