### PR TITLE
Add site association file for iOS Universal Linking support

### DIFF
--- a/source/apple-app-site-association
+++ b/source/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "DQ48D9BF2V.org.cru.godtools",
+                "paths": [ "*" ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Reference: https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html