### PR TITLE
Remove middleman build log suppression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 - 2.2.2
 script:
 - bundle exec rake locales:update
-- bundle exec middleman build >/dev/null 2>/dev/null
+- bundle exec middleman build
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Builds are periodically timing out, and I bet it is from this long running process that has all its output squashed. Long running processes > 10min are liable to be treated as failed builds for reasons unknown.

The problem is described here: https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out