### PR TITLE
Fix issue where pip download fails due to SSL issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 sudo: false
+dist: "trusty"
 language: ruby
 rvm:
 - 2.2.2
+python:
+  - "3.4"
+addons:
+  apt:
+    packages:
+      - "python3-pip"
 install:
 - bundler install
-- pip install awscli
+- pip3 install awscli --user
 script:
 - bundle exec rake locales:update
 - bundle exec middleman build

--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,7 @@ require 'language_name_translation'
 # ========================================================================
 set :site_title,            'KnowGod.com'
 set :site_description,      'KnowGod.com'
-set :site_url_production,   'http://knowgod.com'
+set :site_url_production,   'https://knowgod.com'
 set :site_url_development,  'http://localhost:4567'
 set :css_dir,               'css'
 set :js_dir,                'js'


### PR DESCRIPTION
 - there's an issue with some older versions of python where requests periodically fail over SSL.

The issue is described here: https://www.franzoni.eu/python-requests-ssl-and-insecureplatformwarning/

The fix is to ensure that python 3.4 is installed and use pip3 to install the awscli package