### PR TITLE
GT-427 Improve Chinese language selection

### DIFF
--- a/lib/language_name_translation.rb
+++ b/lib/language_name_translation.rb
@@ -1,6 +1,6 @@
 class LanguageNameTranslation
 
-  SUPPLEMENTARY_TRANSLATIONS = {
+  SUPPLEMENTARY_TRANSLATION_DATA = {
     'TGL' => {
       'EN' => 'Tagalog',
       'TGL' => 'Wikang Tagalog'
@@ -35,6 +35,16 @@ class LanguageNameTranslation
     'SI' => {
       'EN' => 'Sinhala, Sinhalese',
       'SI' => 'සිංහල'
+    },
+    'ZH_HANS' => {
+      'EN' => 'Chinese, Simplified',
+      'ZH_HANS' => '汉语',
+      'ZH_HANT' => '汉语'
+    },
+    'ZH_HANT' => {
+      'EN' => 'Chinese, Traditional',
+      'ZH_HANS' => '漢語',
+      'ZH_HANT' => '漢語'
     }
   }
 
@@ -50,20 +60,29 @@ class LanguageNameTranslation
   private
 
     def translate_name
-      i18n_data_translation.presence ||
-        supplementary_translation.presence ||
-        english_translation.presence ||
+      supplementary_data_translation.presence ||
+        i18n_data_translation.presence ||
+        supplementary_data_english_translation.presence ||
+        i18n_data_english_translation.presence ||
         @language_code.code_with_country
     end
 
-    def supplementary_translation
+    def supplementary_data
       # These hardcoded translations are mostly here to handle the inconsistencies in the God Tools API or missing translations in I18nData
-      translations = SUPPLEMENTARY_TRANSLATIONS[@language_code.code_with_country].presence || SUPPLEMENTARY_TRANSLATIONS[@language_code.code]
-      return nil if translations.blank?
-      translations[@display_in_language_code.code_with_country].presence || translations[@display_in_language_code.code].presence || translations['EN']
+      @supplementary_data ||= SUPPLEMENTARY_TRANSLATION_DATA[@language_code.code_with_country].presence || SUPPLEMENTARY_TRANSLATION_DATA[@language_code.code]
     end
 
-    def english_translation
+    def supplementary_data_translation
+      return nil if supplementary_data.blank?
+      supplementary_data[@display_in_language_code.code_with_country].presence || supplementary_data[@display_in_language_code.code]
+    end
+
+    def supplementary_data_english_translation
+      return nil if supplementary_data.blank?
+      supplementary_data['EN']
+    end
+
+    def i18n_data_english_translation
       i18n_data_translation(display_in_language_code: LanguageCode.new('EN')).presence ||
         I18n.t('language_name_in_english', locale: @language_code.code_with_country).presence ||
         I18n.t('language_name_in_english', locale: @language_code.code)

--- a/locales/am.yml
+++ b/locales/am.yml
@@ -1,5 +1,5 @@
 ---
-am-et:
+am:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: "ሕጎች?"

--- a/locales/fil.yml
+++ b/locales/fil.yml
@@ -1,5 +1,5 @@
 ---
-tgl:
+fil:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: ESPIRITUWAL?
@@ -593,4 +593,4 @@ tgl:
       title: 'Sa sandaling tinanggap mo si Kristo sapamamagitan ng pananampalataya,
         maraming bagay ang nangyari, kasama ang mga sumusunod:'
     title: Pagkilala sa Diyos ng Personal
-  language_name_in_english: Tagalog
+  language_name_in_english: Filipino

--- a/locales/lt-lt.yml
+++ b/locales/lt-lt.yml
@@ -1,5 +1,5 @@
 ---
-lt:
+lt-lt:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: DĖSNIUS?

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -1,5 +1,5 @@
 ---
-sl-si:
+sl:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: ZAKONE?

--- a/locales/zh-hans.yml
+++ b/locales/zh-hans.yml
@@ -1,5 +1,5 @@
 ---
-zh:
+zh-hans:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: "原则吗"

--- a/locales/zh-hant.yml
+++ b/locales/zh-hant.yml
@@ -1,5 +1,5 @@
 ---
-zh-tw:
+zh-hant:
   fourlaws:
     page_0:
       404edd90-1aff-4bb9-83a2-f0d15c46a6e8: "定律嗎？"


### PR DESCRIPTION

The first commit updates the locale files (via script).

The second commit fixes the issue of distinguishing between Simplified Chinese and Traditional. Before this update both languages would be labeled just "Chinese" in the language menu.

We use the i18n_data library to translate the names of languages into other languages, and the constant hash SUPPLEMENTARY_TRANSLATION_DATA to override/fill-in the gaps in that data.

When translations are missing we should fall back to English. So translations are looked-up in this order (where Native is the client's desired language):

1. Look in supplementary data for Native translation.
2. ‎Look in i18n data for Native translation.
3. ‎Look in supplementary data for English translation.
4. ‎Look in i18n data for English translation.
