### PR TITLE
Add deeplink config for crashlytics beta builds

### DIFF
--- a/source/.well-known/assetlinks.json
+++ b/source/.well-known/assetlinks.json
@@ -10,5 +10,17 @@
         "1C:10:CC:D9:97:17:F4:D9:B7:16:37:7C:6C:48:ED:0E:CB:29:C1:F9:6B:8A:FF:B1:E5:23:E3:B9:15:2A:C1:8B"
       ]
     }
+  },
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.keynote.godtools.android.debug",
+      "sha256_cert_fingerprints": [
+        "74:F5:F5:4A:77:5F:1C:20:29:B3:C6:AD:43:E7:4D:EB:C2:DC:F9:2A:51:D7:C4:A5:CC:0D:B2:06:AE:16:A6:BE"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
https://developer.android.com/training/app-links/verify-site-associations#multi-site