### PR TITLE
Deploy dot files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=3600"
     local-dir: build
+    dot_match: true
     skip_cleanup: true
 after_deploy:
   # Allow `awscli` to make requests to CloudFront.


### PR DESCRIPTION
the travis deploy process appears to be skipping the `.well-known` directory. This should hopefully enable support for deploying this directory.

see:
https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/s3.rb#L58
https://ruby-doc.org/core-2.2.0/Dir.html#method-c-glob